### PR TITLE
django 2.1 compatibility fix: using LoginView instead of login functi…

### DIFF
--- a/zinnia/views/mixins/entry_protection.py
+++ b/zinnia/views/mixins/entry_protection.py
@@ -1,5 +1,5 @@
 """Protection mixins for Zinnia views"""
-from django.contrib.auth.views import login
+from django.contrib.auth.views import LoginView
 
 
 class LoginMixin(object):
@@ -12,7 +12,9 @@ class LoginMixin(object):
         """
         Return the login view.
         """
-        return login(self.request, 'zinnia/login.html')
+        return LoginView.as_view(
+            template_name='zinnia/login.html'
+        )(self.request)
 
 
 class PasswordMixin(object):


### PR DESCRIPTION
This PR fixes an issue caused by django 2.1: instead of using the `login` function from `django.contrib.auth.views`, `LoginView` must be used now.